### PR TITLE
feat: Making `commitlint` compatible with `dependabot`

### DIFF
--- a/base.js
+++ b/base.js
@@ -2,12 +2,11 @@ module.exports = {
   parserPreset: 'conventional-changelog-conventionalcommits',
   rules: {
     'body-leading-blank': [2, 'always'],
-    'body-max-line-length': [2, 'always', 72],
+    'body-max-line-length': [2, 'always', 100],
     'footer-leading-blank': [2, 'always'],
     'footer-max-line-length': [2, 'always', 100],
     'header-max-length': [2, 'always', 100],
     'references-empty': [1, 'never'],
-    'scope-empty': [2, 'always'],
     'subject-case': [2, 'always', 'sentence-case'],
     'subject-empty': [2, 'never'],
     'subject-full-stop': [2, 'never', '.'],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@g2crowd/commitlint-config-g2",
-  "version": "1.6.0",
+  "version": "1.7.0",
   "description": "G2 commitlint configuration",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"


### PR DESCRIPTION
Dependabot commit subjects generate scoped commit types (scoping type to `deps`).  We want this behavior, and do not want build to fail on autogenerated dependabot commits due to our rule that prevents scope in commit type.
The second problem this addresses is increasing max body line to 100 characters, allowing dependabot to generate documentation linking to security docs for the update