### PR TITLE
chore: remove sentence-case enforcement

### DIFF
--- a/base.js
+++ b/base.js
@@ -7,7 +7,7 @@ module.exports = {
     'footer-max-line-length': [2, 'always', 100],
     'header-max-length': [2, 'always', 100],
     'references-empty': [1, 'never'],
-    'subject-case': [2, 'always', 'sentence-case'],
+    'subject-case': [2, 'never'],
     'subject-empty': [2, 'never'],
     'subject-full-stop': [2, 'never', '.'],
     'subject-max-length': [2, 'always', 50],


### PR DESCRIPTION
per [ccs](https://www.conventionalcommits.org/en/v1.0.0/#specification) rule #15 units of info that make up a conventional commit MUST NOT be treated as case sensitive with the exception of breaking changes

